### PR TITLE
Add Turnstile protection to signup

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,4 @@
 ENV=DEV
 SECRET_SALT=secret_salt
 SECRET_KEY=secret
+TURNSTILE_SECRET_KEY=your_turnstile_secret_key

--- a/backend/app/api/endpoints/User/controller.py
+++ b/backend/app/api/endpoints/User/controller.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 from app.api import deps
-from app.core import config
 from app.models import User
 from app.schemas.generic import Response
 from app.schemas.token import Token
@@ -23,19 +22,18 @@ def register(
     """
     Register new user.
     """
-    request_origin = request.headers.get("origin")
-    server_host = config.FRONTEND_URL
-    if request_origin and (
-        request_origin == config.FRONTEND_URL
-        or config.FRONTEND_URL_REGEX.match(request_origin)
-    ):
-        server_host = request_origin
+    forwarded_for = request.headers.get("x-forwarded-for", "")
+    remote_ip = request.headers.get("cf-connecting-ip")
+    if not remote_ip and forwarded_for:
+        remote_ip = forwarded_for.split(",")[0].strip()
+    if not remote_ip and request.client:
+        remote_ip = request.client.host
 
     return Response(
         detail=UserService.register(
             db=db,
             user=user,
-            server_host=server_host,
+            remote_ip=remote_ip,
         )
     )
 

--- a/backend/app/api/endpoints/User/service.py
+++ b/backend/app/api/endpoints/User/service.py
@@ -1,9 +1,9 @@
-from typing import Dict
+from typing import Dict, Optional
 
-from app.core import security
+from app.core import security, turnstile, utils
 from app.core.security import verify_password
 from app.models.user import User
-from app.schemas.token import Token
+from app.schemas.token import Token, TokenPayload
 from app.schemas.user import UserCreate, UserCreateClient
 from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
@@ -13,7 +13,9 @@ from .... import crud
 
 class UserService:
     @staticmethod
-    def register(db: Session, user: UserCreateClient, server_host: str) -> str:
+    def register(
+        db: Session, user: UserCreateClient, remote_ip: Optional[str] = None
+    ) -> str:
         if crud.crud_user.get_by_email(db=db, email=user.email):
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
@@ -24,6 +26,15 @@ class UserService:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="User with this username already exists",
+            )
+
+        captcha_valid, _error_codes = turnstile.validate_turnstile_token(
+            user.turnstile_token, remote_ip=remote_ip
+        )
+        if not captcha_valid:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Captcha verification failed. Please try again.",
             )
 
         crud.crud_user.create(
@@ -68,12 +79,6 @@ class UserService:
                 password=password,
             ),
         )
-
-        registration_mail = crud.crud_registration_mail.get_by_email(
-            db=db, email=user.email
-        )
-        if registration_mail:
-            crud.crud_registration_mail.remove(db=db, id=registration_mail.id)
 
         return user
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -28,6 +28,7 @@ class Config(BaseSettings):
     RESEND_API_KEY: str = ""
     EMAIL_FROM: str = ""
     EMAIL_BCC: str = ""
+    TURNSTILE_SECRET_KEY: str = ""
 
     model_config = SettingsConfigDict(
         env_file=str(ENV_FILE), env_file_encoding="utf-8", extra="ignore"

--- a/backend/app/core/turnstile.py
+++ b/backend/app/core/turnstile.py
@@ -1,0 +1,39 @@
+import json
+from typing import Optional, Tuple
+from urllib.error import URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from . import config
+
+SITEVERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+
+
+def validate_turnstile_token(
+    token: str, remote_ip: Optional[str] = None
+) -> Tuple[bool, list[str]]:
+    if not token:
+        return False, ["missing-input-response"]
+    if not config.TURNSTILE_SECRET_KEY:
+        return False, ["missing-input-secret"]
+
+    payload = {
+        "secret": config.TURNSTILE_SECRET_KEY,
+        "response": token,
+    }
+    if remote_ip:
+        payload["remoteip"] = remote_ip
+
+    request = Request(
+        SITEVERIFY_URL,
+        data=urlencode(payload).encode("utf-8"),
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+    try:
+        with urlopen(request, timeout=5) as response:
+            result = json.loads(response.read().decode("utf-8"))
+    except (TimeoutError, URLError, ValueError):
+        return False, ["internal-error"]
+
+    return bool(result.get("success")), list(result.get("error-codes", []))

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -10,6 +10,7 @@ class UserBase(BaseModel):
 
 class UserCreateClient(UserBase):
     password: str
+    turnstile_token: str
 
 
 class UserCreate(UserBase):

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,4 @@
 REACT_APP_BACKEND_URL=http://localhost:8000/api/v1
 REACT_APP_SECRET1_KEY=secret1
 REACT_APP_SECRET2_KEY=secret2
+REACT_APP_TURNSTILE_SITE_KEY=your_turnstile_site_key

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -26,6 +26,11 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <script
+      src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit"
+      async
+      defer
+    ></script>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/frontend/src/pages/RegisterPage.js
+++ b/frontend/src/pages/RegisterPage.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Alert, Button, Form } from "react-bootstrap";
 import Card from "react-bootstrap/Card";
 import { Link, useNavigate } from "react-router-dom";
@@ -9,8 +9,73 @@ import { Logo } from "../components/Logo";
 function RegisterPage() {
 	const [alert, setAlert] = useState(null);
 	const [variant, setVariant] = useState("danger");
+	const [turnstileToken, setTurnstileToken] = useState("");
 	const baseURL = process.env.REACT_APP_BACKEND_URL;
+	const siteKey = process.env.REACT_APP_TURNSTILE_SITE_KEY;
 	const navigate = useNavigate();
+	const turnstileContainerRef = useRef(null);
+	const turnstileWidgetIdRef = useRef(null);
+
+	const resetTurnstile = () => {
+		setTurnstileToken("");
+		if (
+			typeof window !== "undefined"
+			&& window.turnstile
+			&& turnstileWidgetIdRef.current !== null
+		) {
+			window.turnstile.reset(turnstileWidgetIdRef.current);
+		}
+	};
+
+	useEffect(() => {
+		if (!siteKey || !turnstileContainerRef.current || typeof window === "undefined") {
+			return undefined;
+		}
+
+		let isCancelled = false;
+
+		const renderTurnstile = () => {
+			if (
+				isCancelled
+				|| !window.turnstile
+				|| !turnstileContainerRef.current
+				|| turnstileWidgetIdRef.current !== null
+			) {
+				return;
+			}
+
+			turnstileWidgetIdRef.current = window.turnstile.render(
+				turnstileContainerRef.current,
+				{
+					sitekey: siteKey,
+					callback: (token) => {
+						setTurnstileToken(token);
+						setAlert(null);
+					},
+					"expired-callback": () => {
+						setTurnstileToken("");
+					},
+					"error-callback": () => {
+						setTurnstileToken("");
+						setVariant("danger");
+						setAlert("Captcha check failed. Please try again.");
+					},
+				},
+			);
+		};
+
+		renderTurnstile();
+		const intervalId = window.setInterval(renderTurnstile, 250);
+
+		return () => {
+			isCancelled = true;
+			window.clearInterval(intervalId);
+			if (window.turnstile && turnstileWidgetIdRef.current !== null) {
+				window.turnstile.remove(turnstileWidgetIdRef.current);
+				turnstileWidgetIdRef.current = null;
+			}
+		};
+	}, [siteKey]);
 
 	const handleSubmit = async (e) => {
 		e.preventDefault();
@@ -29,17 +94,24 @@ function RegisterPage() {
 			setAlert("Password should be greater than 6");
 			return;
 		}
+		if (siteKey && !turnstileToken) {
+			setVariant("warning");
+			setAlert("Please complete the captcha.");
+			return;
+		}
 		await axios
 			.post(`${baseURL}/user/register/`, {
 				username: e.target["form-username"].value,
 				email: e.target.formBasicEmail.value,
 				password: e.target.formPassword.value,
+				turnstile_token: turnstileToken,
 			})
 			.then(() => {
 				e.target["form-username"].value = null;
 				e.target.formBasicEmail.value = null;
 				e.target.formPassword.value = null;
 				e.target.formConfirmPassword.value = null;
+				resetTurnstile();
 				setVariant("success");
 				setAlert("Account created successfully. Redirecting...");
 				setTimeout(() => {
@@ -47,8 +119,9 @@ function RegisterPage() {
 				}, 1500);
 			})
 			.catch((err) => {
+				resetTurnstile();
 				setVariant("danger");
-				setAlert(err.response.data.detail.toString());
+				setAlert(err.response?.data?.detail?.toString() || "Signup failed.");
 			});
 	};
 
@@ -102,6 +175,14 @@ function RegisterPage() {
 								required
 							/>
 						</Form.Group>
+						{siteKey ? (
+							<Form.Group className="mb-3">
+								<div ref={turnstileContainerRef} />
+								<Form.Text className="text-muted">
+                Complete the captcha before signing up.
+								</Form.Text>
+							</Form.Group>
+						) : null}
 					</div>
 
 					<Button variant="success" type="submit">


### PR DESCRIPTION
## What changed
- added Cloudflare Turnstile to the signup form and verified the token on the backend before account creation
- switched signup to direct account creation without email verification and updated the register UI to collect a password immediately
- documented the new frontend and backend Turnstile environment variables in the example env files

## Why
- the app needed a lightweight anti-bot check after removing email verification from signup
- creating the account immediately keeps signup working without a production email delivery setup

## Validation
- backend py_compile checks passed for the updated auth and Turnstile files
- frontend production build passed with `npm run build`
- backend signup smoke test confirmed invalid captcha returns 400 and valid captcha creates the user
