### PR TITLE
Fix password ownership authorization

### DIFF
--- a/backend/app/api/endpoints/Password/controller.py
+++ b/backend/app/api/endpoints/Password/controller.py
@@ -21,8 +21,12 @@ def create_password(
 
 
 @api.get("/get-password-by-id/{password_id}/", response_model=PasswordClient)
-def get_by_id(db: Session = Depends(deps.get_db), password_id: str = Path(...)) -> Any:
-    return PasswordService.get_password_by_id(db=db, id=password_id)
+def get_by_id(
+    db: Session = Depends(deps.get_db),
+    user: UserClient = Depends(deps.get_current_user),
+    password_id: str = Path(...),
+) -> Any:
+    return PasswordService.get_password_by_id(db=db, id=password_id, user_id=user.id)
 
 
 @api.get("/", response_model=List[PasswordClient])

--- a/backend/app/api/endpoints/Password/controller.py
+++ b/backend/app/api/endpoints/Password/controller.py
@@ -1,8 +1,8 @@
 from typing import Any, List
 
+from app.models.user import User
 from app.schemas.generic import Response
 from app.schemas.password import PasswordClient, PasswordCreateClient, PasswordUpdate
-from app.schemas.user import UserClient
 from fastapi import Body, Depends, Path
 from sqlalchemy.orm import Session
 
@@ -15,7 +15,7 @@ from .service import PasswordService
 def create_password(
     db: Session = Depends(deps.get_db),
     password: PasswordCreateClient = Body(...),
-    user: UserClient = Depends(deps.get_current_user),
+    user: User = Depends(deps.get_current_user),
 ) -> Any:
     return PasswordService.add_password(db=db, password=password, user_id=user.id)
 
@@ -23,7 +23,7 @@ def create_password(
 @api.get("/get-password-by-id/{password_id}/", response_model=PasswordClient)
 def get_by_id(
     db: Session = Depends(deps.get_db),
-    user: UserClient = Depends(deps.get_current_user),
+    user: User = Depends(deps.get_current_user),
     password_id: str = Path(...),
 ) -> Any:
     return PasswordService.get_password_by_id(db=db, id=password_id, user_id=user.id)
@@ -32,7 +32,7 @@ def get_by_id(
 @api.get("/", response_model=List[PasswordClient])
 def get_all(
     db: Session = Depends(deps.get_db),
-    user: UserClient = Depends(deps.get_current_user),
+    user: User = Depends(deps.get_current_user),
 ) -> Any:
     return PasswordService.get_all_by_user_id(db=db, user_id=user.id)
 
@@ -40,7 +40,7 @@ def get_all(
 @api.delete("/delete/{password_id}/", response_model=Response)
 def delete_password_by_id(
     db: Session = Depends(deps.get_db),
-    user: UserClient = Depends(deps.get_current_user),
+    user: User = Depends(deps.get_current_user),
     password_id: str = Path(...),
 ) -> Any:
     return PasswordService.delete_by_id(db=db, id=password_id, user_id=user.id)
@@ -49,7 +49,7 @@ def delete_password_by_id(
 @api.put("/update/{password_id}/")
 def update_password_by_id(
     db: Session = Depends(deps.get_db),
-    user: UserClient = Depends(deps.get_current_user),
+    user: User = Depends(deps.get_current_user),
     password_id: str = Path(...),
     password_update: PasswordUpdate = Body(...),
 ) -> Any:

--- a/backend/app/api/endpoints/Password/service.py
+++ b/backend/app/api/endpoints/Password/service.py
@@ -37,9 +37,9 @@ class PasswordService:
         return Response(detail="Successfully created")
 
     @staticmethod
-    def get_password_by_id(db: Session, id: str) -> Password:
+    def get_password_by_id(db: Session, id: str, user_id: str) -> Password:
         password = crud.crud_password.get(db=db, id=id)
-        if not password:
+        if (not password) or password.user_id != user_id:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail="Password not found"
             )


### PR DESCRIPTION
## What changed
- added the authenticated user dependency to the password get-by-id endpoint
- passed the current user id into the password service lookup
- blocked access to password records not owned by the requester by returning 404

## Why
- the endpoint previously returned any password by raw id without verifying ownership
- that meant any authenticated user who knew or guessed an id could read another user's stored password entry

## Validation
- python3 -m py_compile backend/app/api/endpoints/Password/controller.py backend/app/api/endpoints/Password/service.py
- local commit hooks passed during git commit